### PR TITLE
update rooksource.R for #128

### DIFF
--- a/rook/rooksource.R
+++ b/rook/rooksource.R
@@ -91,30 +91,17 @@ if(!is_rapache_mode){
     if( status!=0 ){
         print("WARNING: Error setting interface or port")
         stop()
-    }   #else{
-    #    unlockBinding("httpdPort", environment(tools:::startDynamicHelp))
-    #    assign("httpdPort", myPort, environment(tools:::startDynamicHelp))
-    #}
+    }
+
+    unlockBinding("httpdPort", environment(tools:::startDynamicHelp))
+    assign("httpdPort", myPort, environment(tools:::startDynamicHelp))
 
     R.server <- Rhttpd$new()
 
     cat("Type:", typeof(R.server), "Class:", class(R.server))
-    #R.server$add(app = File$new(getwd()), name = "pic_dir")
 
-    #rookFilesDir = "/Users/ramanprasad/Documents/github-rp/TwoRavens//data/d3m/o_196seed/data"
-    #<- paste(getwd(), "/../data/d3m", sep="");
-    print("--- rookFilesDir")
-    #print(rookFilesDir)
-    #R.server$add(app = File$new(rookFilesDir), name = "rook-files")
-
-
-    print(R.server)
-
-    #if(!production){
-      R.server$start(listen=myInterface, port=myPort)
-      R.server$listenAddr <- myInterface
-      R.server$listenPort <- myPort
-    #}
+    R.server$listenAddr <- myInterface
+    R.server$listenPort <- myPort
 }
 
 


### PR DESCRIPTION
Fix for #128; allow rook to be accessible outside of the localhost
- **docker**: run rook in a terminal as a separate service
- **docker-compose**: run system, allowing connections between containers
- **k8s**: allow health checks