### PR TITLE
rook restart fix

### DIFF
--- a/rook/rook_nonstop.R
+++ b/rook/rook_nonstop.R
@@ -5,8 +5,13 @@ source('rooksource.R')
 # Now make the console go to sleep. Of course the web server will still be
 # running.
 while (TRUE) {
-  Sys.sleep(1 * 60 * 60) # restart every 24 hours
+  print('(> rook restarts are every 1 hour)')
+  #Sys.sleep(1 * 60 * 1) # restart every 1 minute
+  Sys.sleep(1 * 60 * 60) # restart every 1 hour
+
+  print('> begin rook restart...')
   source("rookzeligrestart.R")
+
 }
 # If we get here then the web server didn't start up properly
 warning("Oops! Couldn't start Rook app")

--- a/rook/rookzeligrestart.R
+++ b/rook/rookzeligrestart.R
@@ -4,7 +4,10 @@
 ##  simple restart of the R.server
 ##
 
-R.server$stop()
+print('> restart step 1')
+#R.server$stop()
 R.server$remove(all=TRUE)
 rm(list=ls())
+
+print('> restart step 2')
 source("rooksource.R")


### PR DESCRIPTION
Fix for #341 

- Rook was stopping every hour
- 2 days ago, this line was removed:
    ```
    R.server$start(listen=myInterface, port=myPort) 
    ```  
- This pull request removes `R.server$stop()` which started to cause an error
- Also added some comment lines for future debugging